### PR TITLE
change consul provider to rescue Diplomat::KeyNotFound

### DIFF
--- a/lib/puppet/provider/key_value_config/consul.rb
+++ b/lib/puppet/provider/key_value_config/consul.rb
@@ -10,14 +10,14 @@ Puppet::Type.type(:key_value_config).provide(:consul) do
     begin
       resp = Diplomat.get(name)
       resp == resource[:value]
-    rescue Faraday::ResourceNotFound
+    rescue Diplomat::KeyNotFound
       false
     end
   end
 
   def create
     Puppet.info("Setting #{name} to #{resource[:value]}")
-    Diplomat.put(name, resource[:value])
+    Diplomat.put(name, resource[:value].to_s)
   end
 
   def destroy

--- a/metadata.json
+++ b/metadata.json
@@ -6,6 +6,6 @@
   "license": "Apache 2.0",
   "source": "git://github.com/garethr/garethr-key_value_config",
   "project_page": "https://github.com/garethr/garethr-key_value_config",
-  "issues_url": "https://github.com/garethr/garethr-key_value_config/issues"
+  "issues_url": "https://github.com/garethr/garethr-key_value_config/issues",
   "dependencies": []
 }

--- a/metadata.json
+++ b/metadata.json
@@ -7,4 +7,5 @@
   "source": "git://github.com/garethr/garethr-key_value_config",
   "project_page": "https://github.com/garethr/garethr-key_value_config",
   "issues_url": "https://github.com/garethr/garethr-key_value_config/issues"
+  "dependencies": []
 }


### PR DESCRIPTION
currently the consul provider does not work so:

change consul provider to rescue Diplomat::KeyNotFound as this is what is actually thrown by diplomat when it cannot find a key

Also ensure that we are attemping to convert the value to a string - as diplomat requires this, this prevents failures with puppet on passing a boolean

fixes #2 
